### PR TITLE
Clear form when clicking on closing button

### DIFF
--- a/board.html
+++ b/board.html
@@ -100,7 +100,7 @@
   <div class="hide slide-out mw1920" id="add-task-pop-up">
     <div id="add-task-close-div">
       <h1>Add Task</h1>
-      <button id="board-add-task-close-button" onclick="popUpAddTask(popup)">X</button>
+      <button id="board-add-task-close-button" onclick="clearTask('render-selected-users-board', 'Select task category', 'category-button', 'drop-down-category-board', 'subtask-render-div'); popUpAddTask(popup)">X</button>
     </div>
     <div class="add-task-form">
       <div class="add-task-text-div">


### PR DESCRIPTION
Fixed an issue where the add task form was not cleared when clicking on the close button instead of the clear button.