### PR TITLE
Legal info disabled under 1165px correctly

### DIFF
--- a/styles/navigation.css
+++ b/styles/navigation.css
@@ -68,4 +68,8 @@ nav a {
     width: 100%;
     z-index: 10;
   }
+
+  .legal-info {
+    display: none;
+  }
 }


### PR DESCRIPTION
Legal notice and privacy policy are not displayed in the range between 1165px and 630px in the navbar anymore.